### PR TITLE
Helper functions for getting canonical names

### DIFF
--- a/cmd/dataset_add.go
+++ b/cmd/dataset_add.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"log"
-	"path/filepath"
-	"strings"
 
 	"github.com/cybera/mimir/internal/datasets"
 	"github.com/cybera/mimir/internal/fetchers"
@@ -26,11 +24,6 @@ var addDatasetCmd = &cobra.Command{
 
 		if !generated && from == "" {
 			log.Fatal("Non-generated datasets require --from to be defined")
-		}
-
-		for i, d := range dependencies {
-			ext := filepath.Ext(d)
-			dependencies[i] = strings.TrimSuffix(d, ext)
 		}
 
 		fetcherConfig := fetchers.FetcherConfig{Name: source, From: from}

--- a/internal/datasets/dataset.go
+++ b/internal/datasets/dataset.go
@@ -4,7 +4,6 @@ import (
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/cybera/mimir/internal/fetchers"
 	"github.com/cybera/mimir/internal/languages"
@@ -81,8 +80,7 @@ func (d Dataset) Fetch() ([]byte, error) {
 }
 
 func (d Dataset) GenerateCode() error {
-	ext := filepath.Ext(d.File)
-	name := strings.TrimSuffix(d.File, ext)
+	name := canonicalName(d.File)
 
 	lang := viper.GetString("PrimaryLanguage")
 	root := viper.GetString("ProjectRoot")

--- a/internal/datasets/repository.go
+++ b/internal/datasets/repository.go
@@ -3,7 +3,6 @@ package datasets
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/cybera/mimir/internal/utils"
 
@@ -18,10 +17,12 @@ func Create(file string, fetcherConfig fetchers.FetcherConfig, generated bool, d
 		return Dataset{}, errors.New("missing file extension")
 	}
 
-	name := strings.TrimSuffix(file, ext)
+	name := canonicalName(file)
 	if _, err := Get(name); err == nil {
 		return Dataset{}, errors.New("dataset already exists")
 	}
+
+	dependencies = canonicalNames(dependencies)
 
 	for _, dep := range dependencies {
 		if _, err := Get(dep); err != nil {
@@ -40,11 +41,11 @@ func Create(file string, fetcherConfig fetchers.FetcherConfig, generated bool, d
 }
 
 func Get(name string) (Dataset, error) {
-	cleanedName := strings.TrimSuffix(name, filepath.Ext(name))
+	name = canonicalName(name)
 
 	var dataset Dataset
 
-	if err := viper.UnmarshalKey("datasets."+cleanedName, &dataset); err != nil {
+	if err := viper.UnmarshalKey("datasets."+name, &dataset); err != nil {
 		return Dataset{}, err
 	}
 

--- a/internal/datasets/utils.go
+++ b/internal/datasets/utils.go
@@ -1,0 +1,23 @@
+package datasets
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// CanonicalName returns the cleaned version of a dataset name, stripped of
+// any extraneous parts like file extension.
+func canonicalName(name string) string {
+	return strings.TrimSuffix(name, filepath.Ext(name))
+}
+
+// CanonicalNames returns the cleaned versions of a list of dataset names.
+func canonicalNames(names []string) []string {
+	var canonicalNames []string
+
+	for _, name := range names {
+		canonicalNames = append(canonicalNames, canonicalName(name))
+	}
+
+	return canonicalNames
+}


### PR DESCRIPTION
We allow users to refer to datasets with or without the file extension
since the name must be unique. However, internally, we do not use the
file extension so must always clean the user input to match. This commit
solidifies the concept of canonical names and provides helper functions
to clean user input rather than having the same code repeated in
multiple places.