### PR TITLE
Fetcher: Change interface to take writer instead of returning bytes

### DIFF
--- a/cmd/dataset_fetch.go
+++ b/cmd/dataset_fetch.go
@@ -84,7 +84,7 @@ func fetch(dataset datasets.Dataset) error {
 		return nil
 	}
 
-	return dataset.FetchAndWrite()
+	return dataset.Fetch()
 }
 
 func init() {

--- a/cmd/dataset_fetch_test.go
+++ b/cmd/dataset_fetch_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -105,12 +106,14 @@ type MockFetcher struct {
 	target string
 }
 
-func (m MockFetcher) Fetch() ([]byte, error) {
+func (m MockFetcher) Fetch(writer io.Writer) error {
 	if m.target != "container/iris.csv" {
-		return nil, errors.New("target not found")
+		return errors.New("target not found")
 	}
 
-	return []byte(contents), nil
+	_, err := writer.Write([]byte(contents))
+
+	return err
 }
 
 func NewMockFetcher(config fetchers.FetcherConfig) (fetchers.Fetcher, error) {

--- a/internal/datasets/dataset.go
+++ b/internal/datasets/dataset.go
@@ -43,8 +43,12 @@ func (d Dataset) Exists() (bool, error) {
 	}
 }
 
-func (d Dataset) FetchAndWrite() error {
-	bytes, err := d.Fetch()
+func (d Dataset) Fetch() error {
+	if d.Generated {
+		return errors.New("can't fetch a generated dataset")
+	}
+
+	fetcher, err := fetchers.NewFetcher(d.FetcherConfig)
 	if err != nil {
 		return err
 	}
@@ -55,29 +59,11 @@ func (d Dataset) FetchAndWrite() error {
 	}
 	defer file.Close()
 
-	if _, err := file.Write(bytes); err != nil {
+	if err := fetcher.Fetch(file); err != nil {
 		return err
 	}
 
 	return nil
-}
-
-func (d Dataset) Fetch() ([]byte, error) {
-	if d.Generated {
-		return nil, errors.New("can't fetch a generated dataset")
-	}
-
-	fetcher, err := fetchers.NewFetcher(d.FetcherConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	bytes, err := fetcher.Fetch()
-	if err != nil {
-		return nil, err
-	}
-
-	return bytes, nil
 }
 
 func (d Dataset) GenerateCode() error {

--- a/internal/fetchers/fetcher.go
+++ b/internal/fetchers/fetcher.go
@@ -1,13 +1,15 @@
 package fetchers
 
 import (
+	"io"
+
 	"github.com/pkg/errors"
 )
 
 var Factories = map[string]func(FetcherConfig) (Fetcher, error){}
 
 type Fetcher interface {
-	Fetch() ([]byte, error)
+	Fetch(io.Writer) error
 }
 
 type FetcherConfig struct {

--- a/internal/fetchers/local.go
+++ b/internal/fetchers/local.go
@@ -1,7 +1,8 @@
 package fetchers
 
 import (
-	"io/ioutil"
+	"io"
+	"os"
 
 	"github.com/pkg/errors"
 )
@@ -14,13 +15,18 @@ func NewLocalFetcher(config FetcherConfig) (Fetcher, error) {
 	return LocalFetcher{path: config.From}, nil
 }
 
-func (f LocalFetcher) Fetch() ([]byte, error) {
-	data, err := ioutil.ReadFile(f.path)
+func (f LocalFetcher) Fetch(writer io.Writer) error {
+	file, err := os.Open(f.path)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to fetch local file")
+		return errors.Wrapf(err, "error opening %s", f.path)
 	}
 
-	return data, nil
+	_, err = io.Copy(writer, file)
+	if err != nil {
+		return errors.Wrapf(err, "error copying %s", f.path)
+	}
+
+	return nil
 }
 
 func init() {


### PR DESCRIPTION
Since the most common and currently only use case for fetching a dataset
is to write it to disk there's no reason to be loading the entire thing
into memory and returning it just for the caller to write it. Instead we
can take a writer as an argument and do a buffered copy. This means we
never load the entire datset into memory and makes working with fetchers
more ergonomic.

This addresses the latter part of #14, but not the swift-specific issue of not handling multi-part files.